### PR TITLE
explore-menu category selection

### DIFF
--- a/frontend/src/Componets/ExploreMenu/ExploreMenu.jsx
+++ b/frontend/src/Componets/ExploreMenu/ExploreMenu.jsx
@@ -50,10 +50,9 @@ export const ExploreMenu = ({ category, setCategory }) => {
               <div
                 key={index}
                 onClick={() => handleCategoryClick(item.menu_name)}
-                className="explore-menu-list-item"
+                className={`explore-menu-list-item ${isActive ? "active" : ""}`} 
               >
                 <img
-                  className={isActive ? "active" : ""}
                   src={item.menu_image}
                   alt={item.menu_name}
                 />


### PR DESCRIPTION
fixes #25 
Enhanced the UI in the "Explore Our Menu" section by adding a clear visual cue for the selected category.

<img width="1618" height="805" alt="image" src="https://github.com/user-attachments/assets/6613282a-cefb-4a3c-8a75-28e322668018" />
//this is how it looks after applying the styles

