### PR TITLE
Fix: footer links navigation (closes #28)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Home from './Pages/Home/Home';
 import Cart from './Pages/Cart/Cart';
 import PlaceOrder from './Pages/PlaceOrder/PlaceOrder';
 import Review from './Pages/Review/Review';
+import Privacy from './Pages/Privacy/Privacy';
 import { Routes, Route } from 'react-router-dom';
 
 import { ToastContainer } from 'react-toastify';
@@ -66,6 +67,7 @@ const App = () => {
           <Route path="/order" element={<PlaceOrder />} />
           <Route path="/review" element={<Review />} />
           <Route path="/about" element={<About/>} />
+          <Route path="/privacy" element={<Privacy/>} />
           
 
         </Routes>

--- a/frontend/src/Componets/Footer/Footer.jsx
+++ b/frontend/src/Componets/Footer/Footer.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "./Footer.css";
 import { assets } from "../../assets/assets";
+import { Link } from "react-router-dom";
 
 const Footer = () => {
   return (
@@ -38,10 +39,10 @@ const Footer = () => {
         <div className="footer-content-mid">
           <h2>COMPANY</h2>
           <ul>
-            <li>Home</li>
-            <a href="/about"><li>About Us</li></a>
-            <li>Delivery</li>
-            <li>Privacy Policy</li>
+            <li><Link to="/">Home</Link></li>
+            <li><Link to="/about">About Us</Link></li>
+            <li><Link to="/order">Delivery</Link></li>
+            <li><Link to="/privacy">Privacy Policy</Link></li>
           </ul>
         </div>
 

--- a/frontend/src/Pages/Privacy/Privacy.css
+++ b/frontend/src/Pages/Privacy/Privacy.css
@@ -1,0 +1,14 @@
+.privacy-page{
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 0 16px;
+  line-height: 1.6;
+}
+.privacy-page h1{
+  margin-bottom: 12px;
+}
+.privacy-page h3{
+  margin-top: 24px;
+}
+
+

--- a/frontend/src/Pages/Privacy/Privacy.jsx
+++ b/frontend/src/Pages/Privacy/Privacy.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import "./Privacy.css";
+
+const Privacy = () => {
+  return (
+    <div className="privacy-page">
+      <h1>Privacy Policy</h1>
+      <p>
+        We respect your privacy. This demo policy explains how we handle data in
+        this application.
+      </p>
+      <h3>Information We Collect</h3>
+      <p>
+        - Account info you provide (name, email)
+        <br />- Order details and delivery address
+      </p>
+      <h3>How We Use Information</h3>
+      <p>
+        - To process orders and provide customer support
+        <br />- To improve app performance and features
+      </p>
+      <h3>Contact</h3>
+      <p>
+        For privacy questions, contact us at support@example.com.
+      </p>
+    </div>
+  );
+};
+
+export default Privacy;
+
+


### PR DESCRIPTION
**Description**
Fixed non-functional footer navigation links under the "COMPANY" section.

**Changes made**
- Linked "Home", "About Us", "Delivery", and "Privacy Policy" to their correct routes/pages.
- Ensured links work across all devices and screen sizes.

**Testing**
- Verified all links navigate correctly on both desktop and mobile.

Screenshots:

<img width="1862" height="1032" alt="Screenshot 2025-08-14 172645" src="https://github.com/user-attachments/assets/8e5aeb45-3c9d-4be9-a6a0-25e583efa75e" />
<img width="1784" height="950" alt="Screenshot 2025-08-14 172706" src="https://github.com/user-attachments/assets/b1cb5bb7-af5d-49c0-9e1b-6cd54c268418" />
<img width="1803" height="800" alt="Screenshot 2025-08-14 172733" src="https://github.com/user-attachments/assets/9abedb24-2970-4627-99be-91cd8bcd5da7" />


**Closes #28** 