### PR TITLE
Add persistent bottom Cart Summary bar 

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,9 @@ import Cart from './Pages/Cart/Cart';
 import PlaceOrder from './Pages/PlaceOrder/PlaceOrder';
 import Review from './Pages/Review/Review';
 import Privacy from './Pages/Privacy/Privacy';
+import CartSummaryBar from "./Componets/CartSummaryBar/CartSummaryBar";
 import { Routes, Route } from 'react-router-dom';
+import ScrollToTop from './Componets/ScrollToTop';
 
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -21,7 +23,7 @@ import About from './Pages/About/About';
 // ✅ Inline arrow styles
 const arrowStyle = {
   position: 'fixed',
-  bottom: '20px',
+  bottom: '60px',
   left: '20px',
   background: '#ea6208ff',
   color: '#fff',
@@ -54,34 +56,35 @@ const App = () => {
       {showLogin && <LoginPopup setShowLogin={setShowLogin} />}
 
       <div className="app">
+        <ScrollToTop/>
         <Navbar setShowLogin={setShowLogin} />
 
         <div style={{ position: "absolute", top: "30px", right: "60px", zIndex: 1000 }}>
-  {/* <ThemeToggle />  */}
-      </div>
+          {/* <ThemeToggle />  */}
+        </div>
 
 
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/cart" element={<Cart />} />
-        <Route path="/order" element={<PlaceOrder />} />
-        <Route path="/review" element={<Review />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/privacy" element={<Privacy />} />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/cart" element={<Cart />} />
+          <Route path="/order" element={<PlaceOrder />} />
+          <Route path="/review" element={<Review />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/privacy" element={<Privacy />} />
 
 
-      </Routes>
+        </Routes>
+        <CartSummaryBar />
+        <ToastContainer position="top-right" autoClose={3000} />
 
-      <ToastContainer position="top-right" autoClose={3000} />
+        {/* ✅ Scroll Arrow Button */}
+        <button onClick={handleArrowClick} style={arrowStyle}>
+          {atFooter ? '↑' : '↓'}
+        </button>
+      </div >
 
-      {/* ✅ Scroll Arrow Button */}
-      <button onClick={handleArrowClick} style={arrowStyle}>
-        {atFooter ? '↑' : '↓'}
-      </button>
-    </div >
-
-      {/* ✅ Footer with ref */ }
-      < div ref = { footerRef } >
+      {/* ✅ Footer with ref */}
+      < div ref={footerRef} >
         <Footer />
       </div >
     </>

--- a/frontend/src/Componets/CartSummaryBar/CartSummaryBar.css
+++ b/frontend/src/Componets/CartSummaryBar/CartSummaryBar.css
@@ -1,0 +1,28 @@
+.cart-summary-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #FC4B32;
+  color: white;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 24px;
+  z-index: 1000;
+  font-weight: bold;
+}
+
+.view-cart-btn {
+  background-color: white;
+  color: #FC4B32;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.view-cart-btn:hover {
+  background-color: #ffe6e6;
+}

--- a/frontend/src/Componets/CartSummaryBar/CartSummaryBar.css
+++ b/frontend/src/Componets/CartSummaryBar/CartSummaryBar.css
@@ -1,10 +1,10 @@
-.cart-summary-bar {
+  .cart-summary-bar {
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #FC4B32;
-  color: white;
+  background-color: var(--cart-bg);
+  color: var(--cart-text);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -14,8 +14,8 @@
 }
 
 .view-cart-btn {
-  background-color: white;
-  color: #FC4B32;
+  background-color: var(--cart-btn-bg);
+  color: var(--cart-btn-text);
   border: none;
   padding: 10px 16px;
   border-radius: 4px;
@@ -24,5 +24,21 @@
 }
 
 .view-cart-btn:hover {
-  background-color: #ffe6e6;
+  background-color: var(--cart-btn-hover);
+}
+
+:root {
+  --cart-bg: #FC4B32;
+  --cart-text: #ffffff;
+  --cart-btn-bg: #ffffff;
+  --cart-btn-text: #FC4B32;
+  --cart-btn-hover: #ffe6e6;
+}
+
+.dark  {
+  --cart-bg: #222222;
+  --cart-text: #f5f5f5;
+  --cart-btn-bg: #444444;
+  --cart-btn-text: #f5f5f5;
+  --cart-btn-hover: #666666;
 }

--- a/frontend/src/Componets/CartSummaryBar/CartSummaryBar.jsx
+++ b/frontend/src/Componets/CartSummaryBar/CartSummaryBar.jsx
@@ -1,0 +1,32 @@
+import React, { useContext } from 'react';
+import './CartSummaryBar.css';
+import { StoreContext } from '../../Context/StoreContext';
+import { useNavigate, useLocation } from 'react-router-dom'; 
+
+const CartSummaryBar = () => {
+  const { cartItem, getTotalCartAmount } = useContext(StoreContext);
+  console.log("🛒 cartItems:", cartItem); 
+  const navigate = useNavigate();
+  const location = useLocation(); 
+
+  const safeCartItems = cartItem || {};
+  const totalItems = Object.values(safeCartItems).reduce((sum, item) => sum + item, 0);
+  const totalAmount = getTotalCartAmount()? getTotalCartAmount() : 0;
+
+  // Don't show if cart is empty or if you're already on the cart page
+  if (totalItems === 0 || location.pathname === '/cart') return null;
+
+  return (
+    <div className="cart-summary-bar">
+      <div className="cart-summary-info">
+        🛒 {totalItems} item{totalItems > 1 ? 's' : ''} | 💵 ₹{totalAmount}
+      </div>
+      <button className="view-cart-btn" onClick={() => navigate('/cart')}>
+        VIEW CART
+      </button>
+    </div>
+  );
+};
+
+export default CartSummaryBar;
+

--- a/frontend/src/Componets/ScrollToTop.jsx
+++ b/frontend/src/Componets/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Issue solved #41 

1-Cart Summary Bar Appears After Adding Items:
-🛒 Shows item count and total price.
-📍 Fixed at the bottom of the screen.
<img width="1885" height="862" alt="Screenshot 2025-08-16 221512" src="https://github.com/user-attachments/assets/1e63cd77-5704-4dfd-ac39-f52e8c7d8e9b" />

2-Clicking "VIEW CART" Takes You to Cart Page (Scrolls to Top)
-🚀 Smooth navigation
-🧹 Automatically scrolls to the top of /cart page.
-🚫 Cart bar hidden on /cart.

<img width="1858" height="869" alt="Screenshot 2025-08-16 221739" src="https://github.com/user-attachments/assets/37b81480-199b-46bf-b5a1-d1073c1f151a" />


Please add label in it Thank You!