### PR TITLE
Add prop-types dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.10.0",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.10.0",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",


### PR DESCRIPTION
This PR adds the `prop-types` dependency to the project.

- Installed via npm to enable prop type checking in React components.
- Updates package.json and package-lock.json accordingly.
- No other code changes are included.

This ensures that React components can validate props and helps catch type-related bugs during development.
