### PR TITLE
Fix: AccountDropdown on home page, dropdown stays open and clickable

### DIFF
--- a/frontend/src/Componets/AccountDropdown/AccountDropdown.css
+++ b/frontend/src/Componets/AccountDropdown/AccountDropdown.css
@@ -1,0 +1,37 @@
+.account-dropdown-wrapper {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.profile-img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: 110%;
+  right: 0;
+  background-color: white;
+  border: 1px solid #ccc;
+  min-width: 150px;
+  z-index: 1000;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.dropdown-menu li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.dropdown-menu li:hover {
+  background-color: #f0f0f0;
+}

--- a/frontend/src/Componets/AccountDropdown/AccountDropdown.jsx
+++ b/frontend/src/Componets/AccountDropdown/AccountDropdown.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useRef, useEffect, useContext } from "react";
+import './AccountDropdown.css';
+import { assets } from '../../assets/assets.js';
+import { useNavigate } from 'react-router-dom';
+import { StoreContext } from '../../Context/StoreContext.jsx';
+
+const AccountDropdown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+  const navigate = useNavigate();
+  const { setToken } = useContext(StoreContext);
+
+  // Close if clicked outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const handleLogout = () => {
+    setToken("");
+    localStorage.removeItem("token");
+    navigate("/");
+  };
+
+  return (
+    <div className="account-dropdown-wrapper" ref={dropdownRef}>
+      <img
+        src={assets.profile_icon}
+        alt="Profile"
+        className="profile-img"
+        onClick={() => setIsOpen(!isOpen)}
+      />
+      {isOpen && (
+        <ul className="dropdown-menu">
+          <li onClick={() => navigate('/orders')}>
+            <img src={assets.bag_icon} alt="orders" /> Orders
+          </li>
+          <li onClick={handleLogout}>
+            <img src={assets.logout_icon} alt="logout" /> Logout
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AccountDropdown;

--- a/frontend/src/Componets/Navbar/Navbar.jsx
+++ b/frontend/src/Componets/Navbar/Navbar.jsx
@@ -5,18 +5,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import { StoreContext } from '../../Context/StoreContext';
 import ThemeToggle from '../ThemeToggle.jsx';
 import { FaBars, FaTimes } from "react-icons/fa";
+import AccountDropdown from '../AccountDropdown/AccountDropdown';
 
 export const Navbar = ({ setShowLogin }) => {
   const [Menu, setMenu] = useState("");
-  const { getTotalCartAmount, token, setToken, cartItem } = useContext(StoreContext);
+  const { getTotalCartAmount, token, cartItem } = useContext(StoreContext);
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
-
-  const handleLogout = () => {
-    setToken("");
-    localStorage.removeItem("token");
-    navigate("/");
-  };
 
   const totalCartItems = Object.values(cartItem || {}).reduce((sum, qty) => sum + qty, 0);
 
@@ -72,19 +67,11 @@ export const Navbar = ({ setShowLogin }) => {
           </div>
         </Link>
 
+        {/* Sign in button or AccountDropdown */}
         {!token ? (
           <button onClick={() => setShowLogin(true)}>Sign in</button>
         ) : (
-          <div className="navbar-profile">
-            <img src={assets.profile_icon} alt="profile" />
-            <ul className="nav-profile-dropdown">
-              <li><img src={assets.bag_icon} alt="orders" /><p>Orders</p></li>
-              <hr />
-              <li onClick={handleLogout}>
-                <img src={assets.logout_icon} alt="logout" /><p>LogOut</p>
-              </li>
-            </ul>
-          </div>
+          <AccountDropdown />
         )}
       </div>
 


### PR DESCRIPTION
Fix: AccountDropdown on home page

- Dropdown now stays open when hovering and is fully clickable
- Includes Orders and Logout functionality
- Styled for proper display in mobile and desktop views

fixes #91 