### PR TITLE
deleted the dublicate logo import

### DIFF
--- a/frontend/src/Componets/Footer/Footer.jsx
+++ b/frontend/src/Componets/Footer/Footer.jsx
@@ -62,7 +62,7 @@ const Footer = () => {
               <img src={assets.github_icon} alt="GitHub" />
             </a>
 
-            <img src={assets.facebook_icon} alt="Facebook" />
+          
 
 
               <a


### PR DESCRIPTION
Solved the issue #104 

**Proposed Solution-**
The Footer had the dual facebook logo import line of code , which makes user difficult to navigate to the right url .
  
The footer now has one facebook URL .

@Skrishna0703 please verify and merger it under GSSOC'25 
Thankyou !!