### PR TITLE
fix(UI): prevent testimonial card clipping in reviews section

### DIFF
--- a/frontend/src/Pages/Review/Review.css
+++ b/frontend/src/Pages/Review/Review.css
@@ -1,6 +1,6 @@
 /* CustomerReviews.css*/
 
- .reviews-section {
+.reviews-section {
   padding: 60px 20px;
   background-color: var(--bg-color);
   text-align: center;
@@ -26,7 +26,7 @@
   width: 100%;
   max-width: 300px;
   min-width: 300px; 
-  height: 420px;
+  /* height: 420px;  ❌ removed fixed height */
   box-sizing: border-box; 
   margin: 0 auto;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
@@ -34,9 +34,10 @@
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start; /* allow content to grow */
+  padding-bottom: 25px; /* ✅ ensures stars/shadows not cut */
 }
-.dark .review-card{
+.dark .review-card {
   box-shadow:  0 4px 12px rgba(233, 77, 77, 0.764);
 }
 
@@ -47,10 +48,12 @@
 
 .review-avatar,
 .review-img {
+}
 .dark .review-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 6px 20px rgba(250, 251, 250, 0.601);
 }
+
 .review-avatar {
   width: 80px;
   height: 80px;
@@ -62,8 +65,6 @@
 .review-card h3 {
   font-size: 1.2rem;
   margin: 10px 0 5px;
-  color: #222;
-  margin: 0;
   color: var(--text-color);
 }
 
@@ -88,53 +89,8 @@
 .stars {
   font-size: 1.2rem;
   color: #ffc107;
-  margin-bottom: 10px; 
+  margin-top: 10px;
 }
-@media (max-width: 768px) {
-  .reviews-section {
-    padding: 40px 15px;
-  }
-
-  .reviews-section h2 {
-    font-size: 1.8rem;
-    margin-bottom: 30px;
-  }
-
-  .reviews-container {
-    gap: 20px;
-  }
-
-  .review-card {
-    width: 90%;
-    padding: 15px;
-  }
-
-  .review-avatar {
-    width: 60px;
-    height: 60px;
-    margin-bottom: 10px;
-  }
-
-  .review-card h3 {
-    font-size: 1rem;
-  }
-
-  .review-comment {
-    font-size: 0.9rem;
-    line-height: 1.3;
-  }
-
-  .review-rating {
-    font-size: 1rem;
-  }
-} 
-
-
-
-
-
-
-
 
 @media (max-width: 768px) {
   .reviews-section {
@@ -173,5 +129,4 @@
   .review-rating {
     font-size: 1rem;
   }
-} 
-
+}

--- a/frontend/src/Pages/Review/Review.jsx
+++ b/frontend/src/Pages/Review/Review.jsx
@@ -95,4 +95,3 @@ const Reviews = () => {
 };
 
 export default Reviews;
-


### PR DESCRIPTION
## Which issue does this PR close?
- #193  

## Rationale for this change
The testimonial/review cards in the **Reviews section** were clipped at the bottom — rating stars and card shadows were cut off due to a fixed height on the cards. This created a poor UI experience.  

This PR removes the fixed height and ensures proper spacing so that cards expand naturally with content.  

## What changes are included in this PR?
- Removed fixed `height: 420px` from `.review-card`.  
- Added `padding-bottom` to ensure rating stars are always visible.  
- Ensured `justify-content: flex-start` so cards adapt to content length.  
- Preserved all existing design, responsiveness, and theming.  

## Are these changes tested?
Yes ✅  
- Manually tested locally on Chrome and Edge at 1920×1080.  
- Tested responsive breakpoints (`<768px`) to confirm mobile layout works correctly.  
- Verified that shadows, rating stars, and spacing render correctly on all screen sizes.  

## Are there any user-facing changes?
Yes.  
- Cards now resize properly according to comment length.  
- Rating stars and shadows are fully visible.  
- Consistent spacing improves the overall look of the Reviews section.  

## Screenshots (if applicable)
**Before (clipped):**  
<img width="1856" height="867" alt="Screenshot 2025-09-19 122228" src="https://github.com/user-attachments/assets/86d5cb53-6fec-4316-bea3-c0bb7ce8137e" />
 

**After (fixed):**  
<img width="1870" height="969" alt="Screenshot 2025-09-21 184305" src="https://github.com/user-attachments/assets/24f94fa5-fce5-4723-8347-ea9042fdec4f" />
 
